### PR TITLE
Do not error on Collect Workfile Representations if current file is unsaved

### DIFF
--- a/client/ayon_substancepainter/plugins/publish/collect_workfile_representation.py
+++ b/client/ayon_substancepainter/plugins/publish/collect_workfile_representation.py
@@ -13,7 +13,11 @@ class CollectWorkfileRepresentation(pyblish.api.InstancePlugin):
     def process(self, instance):
 
         context = instance.context
-        current_file = context.data["currentFile"]
+        current_file = context.data.get("currentFile")
+        if not current_file:
+            self.log.warning("Current file is not saved. File could not be "
+                             "collected as workfile representation.")
+            return
 
         folder, file = os.path.split(current_file)
         filename, ext = os.path.splitext(file)


### PR DESCRIPTION
## Changelog Description
<!-- Paragraphs contain detailed information on the changes made to the product or service, providing an in-depth description of the updates and enhancements. They can be used to explain the reasoning behind the changes, or to highlight the importance of the new features. Paragraphs can often include links to further information or support documentation. -->

Do not error on Collect Workfile Representation if current file is unsaved. Allow invalidation by validators.

## Additional info
<!-- Paragraphs of text giving context of additional technical information or code examples. -->

This is a companion PR to https://github.com/ynput/ayon-core/pull/786
When used together a better error report is shown for unsaved files.

![image](https://github.com/user-attachments/assets/0960fe14-b439-4b44-9f30-5832d03767d0)

(Screenshots from Houdini - should appear similar in Substance painter)

## Testing notes:

1. Use this PR together with https://github.com/ynput/ayon-core/pull/786
2. Try publishing from an unsaved workfile
