### PR TITLE
Replace pyside2 import with qtpy import

### DIFF
--- a/client/ayon_substancepainter/api/pipeline.py
+++ b/client/ayon_substancepainter/api/pipeline.py
@@ -162,7 +162,7 @@ class SubstanceHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         return metadata.get(OPENPYPE_METADATA_CONTEXT_KEY) or {}
 
     def _install_menu(self):
-        from PySide2 import QtWidgets
+        from qtpy import QtWidgets
         from ayon_core.tools.utils import host_tools
 
         parent = substance_painter.ui.get_main_window()

--- a/client/ayon_substancepainter/deploy/plugins/ayon_plugin.py
+++ b/client/ayon_substancepainter/deploy/plugins/ayon_plugin.py
@@ -9,7 +9,7 @@ def cleanup_ayon_qt_widgets():
 
     """
     # TODO: Create a more reliable method to close down all AYON Qt widgets
-    from PySide2 import QtWidgets
+    from qtpy import QtWidgets
     import substance_painter.ui
 
     # Kill AYON Qt widgets


### PR DESCRIPTION
## Changelog Description
This PR is to resolve the error of installing AYON when substance painter is launched.
```
[Python] Traceback (most recent call last):
  File "C:\Program Files/Adobe/Adobe Substance 3D Painter/resources/python\startup\painter_plugins_ui.py", line 58, in manage_plugin
    substance_painter_plugins.reload_plugin(module)
  File "C:\Program Files/Adobe/Adobe Substance 3D Painter/resources/python/modules\substance_painter_plugins.py", line 157, in reload_plugin
    start_plugin(module)
  File "C:\Program Files/Adobe/Adobe Substance 3D Painter/resources/python/modules\substance_painter_plugins.py", line 88, in start_plugin
    module.start_plugin()
  File "D:\ayon-addon_template\ayon-substance-painter\client\ayon_substancepainter\deploy\plugins\ayon_plugin.py", line 26, in start_plugin
    install_host(SubstanceHost())
  File "D:\ayon-core\client\ayon_core\pipeline\context_tools.py", line 129, in install_host
    host.install()
  File "D:\ayon-addon_template\ayon-substance-painter\client\ayon_substancepainter\api\pipeline.py", line 74, in install
    self._install_menu()
  File "D:\ayon-addon_template\ayon-substance-painter\client\ayon_substancepainter\api\pipeline.py", line 165, in _install_menu
    from PySide2 import QtWidgets
ModuleNotFoundError: No module named 'PySide2'
```


## Additional info
n/a


## Testing notes:

1. Install and update addon with this branch
2. Launch Substance
