### PR TITLE
Add filtering options for texture sets

### DIFF
--- a/client/ayon_substancepainter/plugins/create/create_textures.py
+++ b/client/ayon_substancepainter/plugins/create/create_textures.py
@@ -152,7 +152,7 @@ class CreateTextures(Creator):
                     label="Review",
                     tooltip="Mark as reviewable",
                     default=True),
-            EnumDef("exportTextureSet",
+            EnumDef("exportTextureSets",
                     items=export_texture_set_enum,
                     multiselection=True,
                     default=None,

--- a/client/ayon_substancepainter/plugins/create/create_textures.py
+++ b/client/ayon_substancepainter/plugins/create/create_textures.py
@@ -158,9 +158,9 @@ class CreateTextures(Creator):
                     default=None,
                     label="Export Texture Set(s)",
                     tooltip="Choose the texture set(s) which "
-                            "you want to export. The value "
-                            "is 'None' by default which exports "
-                            "all texture sets"),
+                            "you want to export. If no sets are "
+                            "are selected then all texture sets "
+                            "will be exported."),
             EnumDef("exportChannel",
                     items=export_channel_enum,
                     multiselection=True,

--- a/client/ayon_substancepainter/plugins/create/create_textures.py
+++ b/client/ayon_substancepainter/plugins/create/create_textures.py
@@ -142,12 +142,25 @@ class CreateTextures(Creator):
                 "CoatSpecularLevel": "Coat Specular Level",
                 "CoatNormal": "Coat Normal",
             }
+        export_texture_set_enum = {
+            texture_set.name(): texture_set.name()
+            for texture_set in substance_painter.textureset.all_texture_sets()
+        }
 
         return [
             BoolDef("review",
                     label="Review",
                     tooltip="Mark as reviewable",
                     default=True),
+            EnumDef("exportTextureSet",
+                    items=export_texture_set_enum,
+                    multiselection=True,
+                    default=None,
+                    label="Export Texture Set(s)",
+                    tooltip="Choose the texture set(s) which "
+                            "you want to export. The value "
+                            "is 'None' by default which exports "
+                            "all texture sets"),
             EnumDef("exportChannel",
                     items=export_channel_enum,
                     multiselection=True,

--- a/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
+++ b/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
@@ -209,7 +209,6 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
         }
 
         # Create the list of Texture Sets to export.
-        config["exportList"] = []
         export_texture_sets = creator_attrs.get("exportTextureSets", [])
         if not export_texture_sets:
             # Export all texture sets

--- a/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
+++ b/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
@@ -209,12 +209,14 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
         }
 
         # Create the list of Texture Sets to export.
+        config["exportList"] = []
         export_texture_set = creator_attrs.get("exportTextureSet", [])
-        config["exportList"] = [
-            {"rootPath": texture_set.name()}
-            for texture_set in substance_painter.textureset.all_texture_sets()
-            if not export_texture_set or texture_set.name() in export_texture_set
-        ]
+        if export_texture_set:
+            for export_texture in export_texture_set:
+                config["exportList"].append({"rootPath": export_texture})
+        else:
+            for texture_set in substance_painter.textureset.all_texture_sets():
+                config["exportList"].append({"rootPath": texture_set.name()})
 
         # Consider None values from the creator attributes optionals
         for override in config["exportParameters"]:

--- a/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
+++ b/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
@@ -209,9 +209,12 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
         }
 
         # Create the list of Texture Sets to export.
-        config["exportList"] = []
-        for texture_set in substance_painter.textureset.all_texture_sets():
-            config["exportList"].append({"rootPath": texture_set.name()})
+        export_texture_set = creator_attrs.get("exportTextureSet", [])
+        config["exportList"] = [
+            {"rootPath": texture_set.name()}
+            for texture_set in substance_painter.textureset.all_texture_sets()
+            if not export_texture_set or texture_set.name() in export_texture_set
+        ]
 
         # Consider None values from the creator attributes optionals
         for override in config["exportParameters"]:

--- a/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
+++ b/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
@@ -209,14 +209,16 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
         }
 
         # Create the list of Texture Sets to export.
-        config["exportList"] = []
-        export_texture_set = creator_attrs.get("exportTextureSet", [])
-        if export_texture_set:
-            for export_texture in export_texture_set:
-                config["exportList"].append({"rootPath": export_texture})
-        else:
-            for texture_set in substance_painter.textureset.all_texture_sets():
-                config["exportList"].append({"rootPath": texture_set.name()})
+        export_texture_sets = creator_attrs.get("exportTextureSets", [])
+        if not export_texture_sets:
+            export_texture_sets = [
+                texture_set.name() for texture_set in
+                substance_painter.textureset.all_texture_sets()
+            ]
+        config["exportList"] = [
+            {"rootPath": texture_set_name}
+            for texture_set_name in export_texture_sets
+        ]
 
         # Consider None values from the creator attributes optionals
         for override in config["exportParameters"]:

--- a/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
+++ b/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
@@ -210,15 +210,11 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
 
         # Create the list of Texture Sets to export.
         export_texture_sets = creator_attrs.get("exportTextureSets", [])
-        if not export_texture_sets:
-            export_texture_sets = [
-                texture_set.name() for texture_set in
-                substance_painter.textureset.all_texture_sets()
+        if export_texture_sets:
+            config["exportList"] = [
+                {"rootPath": texture_set_name}
+                for texture_set_name in export_texture_sets
             ]
-        config["exportList"] = [
-            {"rootPath": texture_set_name}
-            for texture_set_name in export_texture_sets
-        ]
 
         # Consider None values from the creator attributes optionals
         for override in config["exportParameters"]:

--- a/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
+++ b/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
@@ -215,6 +215,12 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
                 {"rootPath": texture_set_name}
                 for texture_set_name in export_texture_sets
             ]
+        else:
+            config["exportList"] = [
+                {"rootPath": texture_set_name}
+                for texture_set_name in
+                substance_painter.textureset.all_texture_sets()
+            ]
 
         # Consider None values from the creator attributes optionals
         for override in config["exportParameters"]:

--- a/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
+++ b/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
@@ -209,18 +209,19 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
         }
 
         # Create the list of Texture Sets to export.
+        config["exportList"] = []
         export_texture_sets = creator_attrs.get("exportTextureSets", [])
-        if export_texture_sets:
-            config["exportList"] = [
-                {"rootPath": texture_set_name}
-                for texture_set_name in export_texture_sets
-            ]
-        else:
-            config["exportList"] = [
-                {"rootPath": texture_set_name}
-                for texture_set_name in
+        if not export_texture_sets:
+            # Export all texture sets
+            export_texture_sets = [
+                texture_set.name() for texture_set in
                 substance_painter.textureset.all_texture_sets()
             ]
+
+        config["exportList"] = [
+            {"rootPath": texture_set_name}
+            for texture_set_name in export_texture_sets
+        ]
 
         # Consider None values from the creator attributes optionals
         for override in config["exportParameters"]:


### PR DESCRIPTION
## Changelog Description
This PR is to add support for filtering texture sets for texture instances. Users can choose which texture set(s) with `Export Texture Set(s)` they want to export in Ayon. If they leave the options empty, the system will export all texture sets as default.
Resolve https://github.com/ynput/ayon-substance-painter/issues/21, https://github.com/ynput/ayon-substance-painter/issues/18
![image](https://github.com/user-attachments/assets/0ed87ec0-19a7-4464-bdbb-9be186da784c)

## Additional review information
N/A

## Testing notes:
1. Launch Substance Painter
2. Create Texture Instance with/without `Export Texture Set(s)`
3. Publish
