### PR TITLE
Collect instance.data['anatomyData'] for publishing

### DIFF
--- a/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
+++ b/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
@@ -22,7 +22,7 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
     label = "Collect Texture Set images"
     hosts = ["substancepainter"]
     families = ["textureSet"]
-    order = pyblish.api.CollectorOrder
+    order = pyblish.api.CollectorOrder + 0.01
 
     def process(self, instance):
 
@@ -187,6 +187,7 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
 
         creator_attrs = instance.data["creator_attributes"]
         preset_url = creator_attrs["exportPresetUrl"]
+        instance.data["anatomyData"] = instance.context.data["anatomyData"]
         self.log.debug(f"Exporting using preset: {preset_url}")
 
         # See: https://substance3d.adobe.com/documentation/ptpy/api/substance_painter/export  # noqa


### PR DESCRIPTION
## Changelog Description
Resolve https://github.com/ynput/ayon-substance-painter/issues/26

## Additional review information
Should we move the collector just after Collect Anatomy Instance data instead? 

## Testing notes:
1. Launch SP
2. Publish
