### PR TITLE
Support for $uvTileName token in texture name

### DIFF
--- a/client/ayon_substancepainter/api/lib.py
+++ b/client/ayon_substancepainter/api/lib.py
@@ -178,7 +178,7 @@ def get_export_templates(config, format="png", strip_folder=True):
         "DefaultMaterial": {
             "$textureSet_BaseColor(_$colorSpace)(.$udim)": "DefaultMaterial_BaseColor_ACES - ACEScg.1002.png",
             "$textureSet_Emissive(_$colorSpace)(.$udim)": "DefaultMaterial_Emissive_ACES - ACEScg.1002.png",
-            "$textureSet_Height(_$colorSpace)(.$udim)": "DefaultMaterial_Height_Utility - Raw.1002.png",    
+            "$textureSet_Height(_$colorSpace)(.$udim)": "DefaultMaterial_Height_Utility - Raw.1002.png",
             "$textureSet_Metallic(_$colorSpace)(.$udim)": "DefaultMaterial_Metallic_Utility - Raw.1002.png",
             "$textureSet_Normal(_$colorSpace)(.$udim)": "DefaultMaterial_Normal_Utility - Raw.1002.png",    
             "$textureSet_Roughness(_$colorSpace)(.$udim)": "DefaultMaterial_Roughness_Utility - Raw.1002.png"
@@ -208,7 +208,6 @@ def get_export_templates(config, format="png", strip_folder=True):
         cmd = f'alg.mapexport.getPathsExportDocumentMaps("{preset}", "{folder}", "{format}", [])'  # noqa
 
     result = substance_painter.js.evaluate(cmd)
-
     if strip_folder:
         for _stack, maps in result.items():
             for map_template, map_filepath in maps.items():
@@ -224,7 +223,8 @@ def _templates_to_regex(templates,
                         texture_set,
                         colorspaces,
                         project,
-                        mesh):
+                        mesh,
+                        tile_names):
     """Return regex based on a Substance Painter export filename template.
 
     This converts Substance Painter export filename templates like
@@ -263,6 +263,11 @@ def _templates_to_regex(templates,
         # No colorspace support enabled
         colorspace_match = ""
 
+    if tile_names and any(tile_names):
+        tile_name_match = "|".join(tile_names)
+    else:
+        tile_name_match = ""
+
     # Key to regex valid search values
     key_matches = {
         "$project": re.escape(_filename_no_ext(project)),
@@ -274,16 +279,7 @@ def _templates_to_regex(templates,
 
     version_info = substance_painter.application.version_info()
     if version_info >= (11, 0, 1):
-        # \s* pattern would match whitespace characters from the start
-        # [^\W_] requires at least one word character that's no underscore
-        # [\w -]* captures any word character, space or hyphen
-        # (?<! ) ensure the word does not end with space
-        # The pattern handles the cases such as "Table Top", "Table_Top",
-        # "Table-Top", "TableTOp", "Table Top". But it cannot handle
-        # some extreme scenarios such as "TableTop " or " TableTop"
-
-        key_matches["$uvTileName"] = r"(\s*[^\W_](?:[\w -]*(?<! )))"
-
+        key_matches["$uvTileName"] = tile_name_match
     # Turn the templates into regexes
     regexes = {}
     for template in templates:
@@ -350,7 +346,6 @@ def strip_template(template, strip="._ "):
     version_info = substance_painter.application.version_info()
     if version_info >= (11, 0, 1):
         keys.append("$uvTileName")
-
     stripped_template = template
     for key in keys:
         stripped_template = stripped_template.replace(key, "")
@@ -452,6 +447,11 @@ def get_parsed_export_maps(config, strip_texture_set=False):
     for key, filepaths in outputs.items():
         texture_set, stack = key
 
+        texture_name = (
+            substance_painter.textureset.TextureSet.from_name(texture_set)
+        )
+        tile_names = set(tile.name for tile in texture_name.all_uv_tiles())
+
         if stack:
             stack_path = f"{texture_set}/{stack}"
         else:
@@ -467,8 +467,8 @@ def get_parsed_export_maps(config, strip_texture_set=False):
                                              texture_set=texture_set,
                                              colorspaces=project_colorspaces,
                                              mesh=project_mesh_path,
-                                             project=project_path)
-
+                                             project=project_path,
+                                             tile_names=tile_names)
         # Let's precompile the regexes
         for template, regex in template_regex.items():
             template_regex[template] = re.compile(regex)
@@ -517,7 +517,12 @@ def get_stack_results(stack_results, template_regex,
             parsed = match.groupdict(default={})
             parsed["output"] = filename  # Add filename for convenience
             parsed["filepath"] = filepath  # Add filepath for convenience
-            stack_results[template].append(parsed)
+            uv_tilename = parsed.get("uvTileName", "")
+            if uv_tilename:
+                updated_key = (template, uv_tilename)
+            else:
+                updated_key = (template, "")
+            stack_results[updated_key].append(parsed)
             break
     else:
         if not strip_texture_set:

--- a/client/ayon_substancepainter/api/lib.py
+++ b/client/ayon_substancepainter/api/lib.py
@@ -519,10 +519,6 @@ def get_stack_results(stack_results, template_regex,
     return stack_results
 
 
-def get_uvtilename_from_token(stack_results):
-    pass
-
-
 def get_parsed_output_maps_as_single_output(result):
     """Get parsed output maps as single output
 

--- a/client/ayon_substancepainter/api/lib.py
+++ b/client/ayon_substancepainter/api/lib.py
@@ -248,7 +248,7 @@ def _templates_to_regex(templates,
         colorspaces (list): The colorspaces defined in the current project.
         project (str): Filepath of current substance project.
         mesh (str): Path to mesh file used in current project.
-        mesh (str): The uvTileName set in the template in current project.
+        tile_names (str): The uvTileName set in the template in current project.
 
     Returns:
         dict: Template: Template regex pattern

--- a/client/ayon_substancepainter/api/lib.py
+++ b/client/ayon_substancepainter/api/lib.py
@@ -272,6 +272,10 @@ def _templates_to_regex(templates,
         "$udim": "([0-9]{4})"
     }
 
+    version_info = substance_painter.application.version_info()
+    if version_info >= (11, 0, 1):
+        key_matches["$uvTileName"] = r"(\s*[^\W_](?:[\w -]*(?<! )))"
+
     # Turn the templates into regexes
     regexes = {}
     for template in templates:
@@ -335,6 +339,10 @@ def strip_template(template, strip="._ "):
     # Return only characters that were part of the template that were static.
     # Remove all keys
     keys = ["$project", "$mesh", "$textureSet", "$udim", "$colorSpace"]
+    version_info = substance_painter.application.version_info()
+    if version_info >= (11, 0, 1):
+        keys.append("$uvTileName")
+
     stripped_template = template
     for key in keys:
         stripped_template = stripped_template.replace(key, "")
@@ -369,7 +377,7 @@ def get_parsed_export_maps(config, strip_texture_set=False):
 
     This tries to parse the texture outputs using a Python API export config.
 
-    Parses template keys: $project, $mesh, $textureSet, $colorSpace, $udim
+    Parses template keys: $project, $mesh, $textureSet, $colorSpace, $udim, $uvTileName
 
     Example:
     {("DefaultMaterial", ""): {
@@ -508,6 +516,10 @@ def get_stack_results(stack_results, template_regex,
             raise ValueError(f"Unable to match {filename} against any "
                              f"template in: {list(template_regex.keys())}")
     return stack_results
+
+
+def get_uvtilename_from_token(stack_results):
+    pass
 
 
 def get_parsed_output_maps_as_single_output(result):

--- a/client/ayon_substancepainter/api/lib.py
+++ b/client/ayon_substancepainter/api/lib.py
@@ -274,6 +274,14 @@ def _templates_to_regex(templates,
 
     version_info = substance_painter.application.version_info()
     if version_info >= (11, 0, 1):
+        # \s* pattern would match whitespace characters from the start
+        # [^\W_] requires at least one word character that's no underscore
+        # [\w -]* captures any word character, space or hyphen
+        # (?<! ) ensure the word does not end with space
+        # The pattern handles the cases such as "Table Top", "Table_Top",
+        # "Table-Top", "TableTOp", "Table Top". But it cannot handle
+        # some extreme scenarios such as "TableTop " or " TableTop"
+
         key_matches["$uvTileName"] = r"(\s*[^\W_](?:[\w -]*(?<! )))"
 
     # Turn the templates into regexes

--- a/client/ayon_substancepainter/api/lib.py
+++ b/client/ayon_substancepainter/api/lib.py
@@ -377,7 +377,8 @@ def get_parsed_export_maps(config, strip_texture_set=False):
 
     This tries to parse the texture outputs using a Python API export config.
 
-    Parses template keys: $project, $mesh, $textureSet, $colorSpace, $udim, $uvTileName
+    Parses template keys: $project, $mesh, $textureSet, $colorSpace,
+                          $udim, $uvTileName
 
     Example:
     {("DefaultMaterial", ""): {

--- a/client/ayon_substancepainter/api/lib.py
+++ b/client/ayon_substancepainter/api/lib.py
@@ -381,7 +381,7 @@ def get_parsed_export_maps(config, strip_texture_set=False):
 
     This tries to parse the texture outputs using a Python API export config.
 
-    Parses template keys: $project, $mesh, $textureSet, $colorSpace,
+    Parses template keys: $project, $mesh, , $colorSpace,
                           $udim, $uvTileName
 
     Example:
@@ -460,7 +460,7 @@ def get_parsed_export_maps(config, strip_texture_set=False):
             stack_path = texture_set_name
         if strip_texture_set:
             stack_templates = list(
-                template.replace("_$textureSet", "")
+                re.sub(r"[_.-]?\$textureSet[_.-]?", "", template)
                 for template in templates[stack_path].keys()
             )
         else:
@@ -487,7 +487,6 @@ def get_parsed_export_maps(config, strip_texture_set=False):
             filename = filepath[len(export_path):]
             stack_results = get_stack_results(stack_results, template_regex,
                                               filename, filepath,
-                                              texture_set_name,
                                               strip_texture_set=strip_texture_set)
 
         result[key] = dict(stack_results)
@@ -499,19 +498,9 @@ def get_parsed_export_maps(config, strip_texture_set=False):
 
 def get_stack_results(stack_results, template_regex,
                       filename, filepath,
-                      texture_set,
                       strip_texture_set=False):
     """Function to get filename and filepath for parsed outputs
     """
-    # Strip texture_set and stack_path if required
-    if strip_texture_set:
-        filename = filename.replace(f"_{texture_set}", "")
-        filepath = filepath.replace(f"_{texture_set}", "")
-        template_regex = {
-            template.replace("_$textureSet", ""): regex
-            for template, regex in template_regex.items()
-        }
-
     # Attempt to match the filename against each template
     for template, regex in template_regex.items():
         match = regex.match(filename)
@@ -758,8 +747,9 @@ def get_filtered_export_preset(export_preset_name, channel_type_names,
     for channel_map in maps:
         if strip_texture_set:
             old_channel_map = channel_map["fileName"]
-            channel_map["fileName"] = old_channel_map.replace(
-                "_$textureSet", ""
+            channel_map["fileName"] = re.sub(
+                r"[_.-]?\$textureSet[_.-]?", "",
+                old_channel_map
             )
             # export_preset_name = custom_export_preset
             all_output_maps.append(channel_map)

--- a/client/ayon_substancepainter/api/lib.py
+++ b/client/ayon_substancepainter/api/lib.py
@@ -248,7 +248,8 @@ def _templates_to_regex(templates,
         colorspaces (list): The colorspaces defined in the current project.
         project (str): Filepath of current substance project.
         mesh (str): Path to mesh file used in current project.
-        tile_names (str): The uvTileName set in the template in current project.
+        tile_names (str): The uvTileName set in the template in
+                          the current project.
 
     Returns:
         dict: Template: Template regex pattern

--- a/client/ayon_substancepainter/api/lib.py
+++ b/client/ayon_substancepainter/api/lib.py
@@ -248,6 +248,7 @@ def _templates_to_regex(templates,
         colorspaces (list): The colorspaces defined in the current project.
         project (str): Filepath of current substance project.
         mesh (str): Path to mesh file used in current project.
+        mesh (str): The uvTileName set in the template in current project.
 
     Returns:
         dict: Template: Template regex pattern
@@ -263,10 +264,7 @@ def _templates_to_regex(templates,
         # No colorspace support enabled
         colorspace_match = ""
 
-    if tile_names and any(tile_names):
-        tile_name_match = "|".join(tile_names)
-    else:
-        tile_name_match = ""
+    tile_name_match = "|".join(tile_names) if tile_names else ""
 
     # Key to regex valid search values
     key_matches = {
@@ -445,17 +443,18 @@ def get_parsed_export_maps(config, strip_texture_set=False):
     # Parse the outputs
     result = {}
     for key, filepaths in outputs.items():
-        texture_set, stack = key
+        texture_set_name, stack = key
 
-        texture_name = (
-            substance_painter.textureset.TextureSet.from_name(texture_set)
+        texture_set = (
+            substance_painter.textureset.TextureSet.from_name(
+                texture_set_name)
         )
-        tile_names = set(tile.name for tile in texture_name.all_uv_tiles())
+        tile_names = set(tile.name for tile in texture_set.all_uv_tiles())
 
         if stack:
-            stack_path = f"{texture_set}/{stack}"
+            stack_path = f"{texture_set_name}/{stack}"
         else:
-            stack_path = texture_set
+            stack_path = texture_set_name
         if strip_texture_set:
             stack_templates = list(
                 template.replace("_$textureSet", "")
@@ -464,7 +463,7 @@ def get_parsed_export_maps(config, strip_texture_set=False):
         else:
             stack_templates = list(templates[stack_path].keys())
         template_regex = _templates_to_regex(stack_templates,
-                                             texture_set=texture_set,
+                                             texture_set=texture_set_name,
                                              colorspaces=project_colorspaces,
                                              mesh=project_mesh_path,
                                              project=project_path,
@@ -485,7 +484,7 @@ def get_parsed_export_maps(config, strip_texture_set=False):
             filename = filepath[len(export_path):]
             stack_results = get_stack_results(stack_results, template_regex,
                                               filename, filepath,
-                                              texture_set,
+                                              texture_set_name,
                                               strip_texture_set=strip_texture_set)
 
         result[key] = dict(stack_results)

--- a/client/ayon_substancepainter/api/lib.py
+++ b/client/ayon_substancepainter/api/lib.py
@@ -755,7 +755,7 @@ def get_filtered_export_preset(export_preset_name, channel_type_names,
             all_output_maps.append(channel_map)
         else:
             all_output_maps = maps
-
+    print("all_output_maps", all_output_maps)
     for channel_map in all_output_maps:
         if channel_type_names:
             for channel_name in channel_type_names:

--- a/client/ayon_substancepainter/api/lib.py
+++ b/client/ayon_substancepainter/api/lib.py
@@ -277,8 +277,9 @@ def _templates_to_regex(templates,
     }
 
     version_info = substance_painter.application.version_info()
-    if version_info >= (11, 0, 1):
+    if version_info >= (11, 0, 0):
         key_matches["$uvTileName"] = tile_name_match
+
     # Turn the templates into regexes
     regexes = {}
     for template in templates:
@@ -343,8 +344,9 @@ def strip_template(template, strip="._ "):
     # Remove all keys
     keys = ["$project", "$mesh", "$textureSet", "$udim", "$colorSpace"]
     version_info = substance_painter.application.version_info()
-    if version_info >= (11, 0, 1):
+    if version_info >= (11, 0, 0):
         keys.append("$uvTileName")
+
     stripped_template = template
     for key in keys:
         stripped_template = stripped_template.replace(key, "")

--- a/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
+++ b/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
@@ -47,44 +47,33 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
         # a product per generated texture or texture UDIM sequence
         for (texture_set_name, stack_name), template_maps in maps.items():
             self.log.info(f"Processing {texture_set_name}/{stack_name}")
-            for template, outputs in template_maps.items():
-                self.log.info(f"Processing {template}")
-                # check $uvTileName included as a key value in outputs dict
-                outputs_with_tilenames = [
-                    output for output in outputs
-                    if output.get("uvTileName", "")
-                ]
-                if outputs_with_tilenames:
-                    for output in outputs_with_tilenames:
-                        self.create_image_instance_by_tilename(
-                            instance, template, output,
-                            task_entity=task_entity,
-                            texture_set_name=texture_set_name,
-                            stack_name=stack_name,
-                            strip_texture_set=strip_texture_set
-                        )
-                else:
-                    self.create_image_instance(
-                        instance, template, outputs,
-                        task_entity=task_entity,
-                        texture_set_name=texture_set_name,
-                        stack_name=stack_name,
-                        strip_texture_set=strip_texture_set
-                    )
+            for (template, tilename), outputs in template_maps.items():
+                self.log.info(f"Processing {template} with UV tile name {tilename}")
+                self.create_image_instance(instance, template, outputs,
+                                           task_entity=task_entity,
+                                           texture_set_name=texture_set_name,
+                                           stack_name=stack_name,
+                                           uv_tile_name=tilename,
+                                           strip_texture_set=strip_texture_set)
 
     def create_image_instance(self, instance, template, outputs,
                               task_entity, texture_set_name, stack_name,
+                              uv_tile_name="",
                               strip_texture_set=False):
         """Create a new instance per image or UDIM sequence.
 
         The new instances will be of product type `image`.
 
         """
+
+        context = instance.context
         first_filepath = outputs[0]["filepath"]
         fnames = [os.path.basename(output["filepath"]) for output in outputs]
         ext = os.path.splitext(first_filepath)[1]
         assert ext.lstrip("."), f"No extension: {ext}"
 
+
+        # all_texture_sets = substance_painter.textureset.all_texture_sets()
         # Define the suffix we want to give this particular texture
         # set and set up a remapped product naming for it.
         suffix = ""
@@ -98,94 +87,18 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
                 # More than one stack, include stack name
                 suffix += f".{stack_name}"
 
-        # Always include the map identifier
-        map_identifier = strip_template(template)
-        suffix += f".{map_identifier}"
-
-        # Prepare representation
-        representation = {
-            "name": ext.lstrip("."),
-            "ext": ext.lstrip("."),
-            "files": fnames if len(fnames) > 1 else fnames[0],
-        }
-
-        # Mark as UDIM explicitly if it has UDIM tiles.
-        if bool(outputs[0].get("udim")):
-            # The representation for a UDIM sequence should have a `udim` key
-            # that is a list of all udim tiles (str) like: ["1001", "1002"]
-            # strings. See CollectTextures plug-in and Integrators.
-            representation["udim"] = [output["udim"] for output in outputs]
-
-        self.prepare_image_instance(
-            instance, task_entity, representation,
-            suffix, first_filepath, outputs[0],
-            texture_set_name, stack_name
-        )
-
-    def create_image_instance_by_tilename(self, instance, template, output,
-                                          task_entity, texture_set_name,
-                                          stack_name, strip_texture_set=False):
-        """Create a new instance per image by $uvTileNAme.
-
-        The new instances will be of product type `image`.
-
-        """
-        first_filepath = output["filepath"]
-        fnames = os.path.basename(output["filepath"])
-        ext = os.path.splitext(first_filepath)[1]
-        assert ext.lstrip("."), f"No extension: {ext}"
-
-        # Define the suffix we want to give this particular texture
-        # set and set up a remapped product naming for it.
-        uv_tile_name = output["uvTileName"]
-        suffix = f".{uv_tile_name}"
-        if not strip_texture_set:
-            texture_set = substance_painter.textureset.TextureSet.from_name(
-                texture_set_name
-            )
-            # More than one texture set, include texture set name
-            suffix += f".{texture_set_name}"
-            if texture_set.is_layered_material() and stack_name:
-                # More than one stack, include stack name
-                suffix += f".{stack_name}"
+        if uv_tile_name:
+            suffix += f".{uv_tile_name}"
 
         # Always include the map identifier
         map_identifier = strip_template(template)
         suffix += f".{map_identifier}"
-
-        # Prepare representation
-        representation = {
-            "name": ext.lstrip("."),
-            "ext": ext.lstrip("."),
-            "files": fnames,
-        }
-
-        # Mark as UDIM explicitly if it has UDIM tiles.
-        if bool(output.get("udim")):
-            representation["udim"] = [output["udim"]]
-
-        self.prepare_image_instance(
-            instance, task_entity, representation,
-            suffix, first_filepath, output,
-            texture_set_name, stack_name
-        )
-
-    def prepare_image_instance(
-            self, instance, task_entity, representation,
-            suffix, first_filepath, output,
-            texture_set_name, stack_name
-        ):
-        """Prepare the relevant instance data for image
-        instance(s) to be published.
-
-        """
-
-        context = instance.context
 
         task_name = task_type = None
         if task_entity:
             task_name = task_entity["name"]
             task_type = task_entity["taskType"]
+
         # TODO: The product type actually isn't 'texture' currently but
         #   for now this is only done so the product name starts with
         #   'texture'
@@ -207,6 +120,20 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
             variant=instance.data["variant"],
             project_settings=context.data["project_settings"]
         )
+
+        # Prepare representation
+        representation = {
+            "name": ext.lstrip("."),
+            "ext": ext.lstrip("."),
+            "files": fnames if len(fnames) > 1 else fnames[0],
+        }
+
+        # Mark as UDIM explicitly if it has UDIM tiles.
+        if bool(outputs[0].get("udim")):
+            # The representation for a UDIM sequence should have a `udim` key
+            # that is a list of all udim tiles (str) like: ["1001", "1002"]
+            # strings. See CollectTextures plug-in and Integrators.
+            representation["udim"] = [output["udim"] for output in outputs]
 
         # Set up the representation for thumbnail generation
         # TODO: Simplify this once thumbnail extraction is refactored
@@ -238,7 +165,7 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
 
         # Store color space with the instance
         # Note: The extractor will assign it to the representation
-        colorspace = output.get("colorSpace")
+        colorspace = outputs[0].get("colorSpace")
         if colorspace:
             self.log.debug(f"{image_product_name} colorspace: {colorspace}")
             image_instance.data["colorspace"] = colorspace

--- a/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
+++ b/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
@@ -48,7 +48,9 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
         for (texture_set_name, stack_name), template_maps in maps.items():
             self.log.info(f"Processing {texture_set_name}/{stack_name}")
             for (template, tilename), outputs in template_maps.items():
-                self.log.info(f"Processing {template} with tile name {tilename}")             # noqa: E501
+                self.log.info(
+                    f"Processing {template} with tile name {tilename}"
+                )
                 self.create_image_instance(instance, template, outputs,
                                            task_entity=task_entity,
                                            texture_set_name=texture_set_name,

--- a/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
+++ b/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
@@ -51,7 +51,8 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
                 self.log.info(f"Processing {template}")
                 # check $uvTileName included as a key value in outputs dict
                 outputs_with_tilenames = [
-                    output for output in outputs if output.get("uvTileName", "")
+                    output for output in outputs
+                    if output.get("uvTileName", "")
                 ]
                 if outputs_with_tilenames:
                     for output in outputs_with_tilenames:
@@ -124,6 +125,11 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
     def create_image_instance_by_tilename(self, instance, template, output,
                                           task_entity, texture_set_name,
                                           stack_name, strip_texture_set=False):
+        """Create a new instance per image by $uvTileNAme.
+
+        The new instances will be of product type `image`.
+
+        """
         first_filepath = output["filepath"]
         fnames = os.path.basename(output["filepath"])
         ext = os.path.splitext(first_filepath)[1]

--- a/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
+++ b/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
@@ -46,9 +46,9 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
         # Let's break the instance into multiple instances to integrate
         # a product per generated texture or texture UDIM sequence
         for (texture_set_name, stack_name), template_maps in maps.items():
-            self.log.info(f"Processing {texture_set_name}/{stack_name}")
+            self.log.info(f"Processing {texture_set_name}/{stack_name}")            # noqa: E501
             for (template, tilename), outputs in template_maps.items():
-                self.log.info(f"Processing {template} with UV tile name {tilename}")
+                self.log.info(f"Processing {template} with tile name {tilename}")
                 self.create_image_instance(instance, template, outputs,
                                            task_entity=task_entity,
                                            texture_set_name=texture_set_name,

--- a/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
+++ b/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
@@ -49,11 +49,27 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
             self.log.info(f"Processing {texture_set_name}/{stack_name}")
             for template, outputs in template_maps.items():
                 self.log.info(f"Processing {template}")
-                self.create_image_instance(instance, template, outputs,
-                                           task_entity=task_entity,
-                                           texture_set_name=texture_set_name,
-                                           stack_name=stack_name,
-                                           strip_texture_set=strip_texture_set)
+                # check $uvTileName included as a key value in outputs dict
+                outputs_with_tilenames = [
+                    output for output in outputs if output.get("uvTileName", "")
+                ]
+                if outputs_with_tilenames:
+                    for output in outputs_with_tilenames:
+                        self.create_image_instance_by_tilename(
+                            instance, template, output,
+                            task_entity=task_entity,
+                            texture_set_name=texture_set_name,
+                            stack_name=stack_name,
+                            strip_texture_set=strip_texture_set
+                        )
+                else:
+                    self.create_image_instance(
+                        instance, template, outputs,
+                        task_entity=task_entity,
+                        texture_set_name=texture_set_name,
+                        stack_name=stack_name,
+                        strip_texture_set=strip_texture_set
+                    )
 
     def create_image_instance(self, instance, template, outputs,
                               task_entity, texture_set_name, stack_name,
@@ -63,15 +79,11 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
         The new instances will be of product type `image`.
 
         """
-
-        context = instance.context
         first_filepath = outputs[0]["filepath"]
         fnames = [os.path.basename(output["filepath"]) for output in outputs]
         ext = os.path.splitext(first_filepath)[1]
         assert ext.lstrip("."), f"No extension: {ext}"
 
-
-        # all_texture_sets = substance_painter.textureset.all_texture_sets()
         # Define the suffix we want to give this particular texture
         # set and set up a remapped product naming for it.
         suffix = ""
@@ -89,11 +101,85 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
         map_identifier = strip_template(template)
         suffix += f".{map_identifier}"
 
+        # Prepare representation
+        representation = {
+            "name": ext.lstrip("."),
+            "ext": ext.lstrip("."),
+            "files": fnames if len(fnames) > 1 else fnames[0],
+        }
+
+        # Mark as UDIM explicitly if it has UDIM tiles.
+        if bool(outputs[0].get("udim")):
+            # The representation for a UDIM sequence should have a `udim` key
+            # that is a list of all udim tiles (str) like: ["1001", "1002"]
+            # strings. See CollectTextures plug-in and Integrators.
+            representation["udim"] = [output["udim"] for output in outputs]
+
+        self.prepare_image_instance(
+            instance, task_entity, representation,
+            suffix, first_filepath, outputs[0],
+            texture_set_name, stack_name
+        )
+
+    def create_image_instance_by_tilename(self, instance, template, output,
+                                          task_entity, texture_set_name,
+                                          stack_name, strip_texture_set=False):
+        first_filepath = output["filepath"]
+        fnames = os.path.basename(output["filepath"])
+        ext = os.path.splitext(first_filepath)[1]
+        assert ext.lstrip("."), f"No extension: {ext}"
+
+        # Define the suffix we want to give this particular texture
+        # set and set up a remapped product naming for it.
+        uv_tile_name = output["uvTileName"]
+        suffix = f".{uv_tile_name}"
+        if not strip_texture_set:
+            texture_set = substance_painter.textureset.TextureSet.from_name(
+                texture_set_name
+            )
+            # More than one texture set, include texture set name
+            suffix += f".{texture_set_name}"
+            if texture_set.is_layered_material() and stack_name:
+                # More than one stack, include stack name
+                suffix += f".{stack_name}"
+
+        # Always include the map identifier
+        map_identifier = strip_template(template)
+        suffix += f".{map_identifier}"
+
+        # Prepare representation
+        representation = {
+            "name": ext.lstrip("."),
+            "ext": ext.lstrip("."),
+            "files": fnames,
+        }
+
+        # Mark as UDIM explicitly if it has UDIM tiles.
+        if bool(output.get("udim")):
+            representation["udim"] = [output["udim"]]
+
+        self.prepare_image_instance(
+            instance, task_entity, representation,
+            suffix, first_filepath, output,
+            texture_set_name, stack_name
+        )
+
+    def prepare_image_instance(
+            self, instance, task_entity, representation,
+            suffix, first_filepath, output,
+            texture_set_name, stack_name
+        ):
+        """Prepare the relevant instance data for image
+        instance(s) to be published.
+
+        """
+
+        context = instance.context
+
         task_name = task_type = None
         if task_entity:
             task_name = task_entity["name"]
             task_type = task_entity["taskType"]
-
         # TODO: The product type actually isn't 'texture' currently but
         #   for now this is only done so the product name starts with
         #   'texture'
@@ -115,20 +201,6 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
             variant=instance.data["variant"],
             project_settings=context.data["project_settings"]
         )
-
-        # Prepare representation
-        representation = {
-            "name": ext.lstrip("."),
-            "ext": ext.lstrip("."),
-            "files": fnames if len(fnames) > 1 else fnames[0],
-        }
-
-        # Mark as UDIM explicitly if it has UDIM tiles.
-        if bool(outputs[0].get("udim")):
-            # The representation for a UDIM sequence should have a `udim` key
-            # that is a list of all udim tiles (str) like: ["1001", "1002"]
-            # strings. See CollectTextures plug-in and Integrators.
-            representation["udim"] = [output["udim"] for output in outputs]
 
         # Set up the representation for thumbnail generation
         # TODO: Simplify this once thumbnail extraction is refactored
@@ -160,7 +232,7 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
 
         # Store color space with the instance
         # Note: The extractor will assign it to the representation
-        colorspace = outputs[0].get("colorSpace")
+        colorspace = output.get("colorSpace")
         if colorspace:
             self.log.debug(f"{image_product_name} colorspace: {colorspace}")
             image_instance.data["colorspace"] = colorspace

--- a/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
+++ b/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
@@ -46,9 +46,9 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
         # Let's break the instance into multiple instances to integrate
         # a product per generated texture or texture UDIM sequence
         for (texture_set_name, stack_name), template_maps in maps.items():
-            self.log.info(f"Processing {texture_set_name}/{stack_name}")            # noqa: E501
+            self.log.info(f"Processing {texture_set_name}/{stack_name}")
             for (template, tilename), outputs in template_maps.items():
-                self.log.info(f"Processing {template} with tile name {tilename}")
+                self.log.info(f"Processing {template} with tile name {tilename}")             # noqa: E501
                 self.create_image_instance(instance, template, outputs,
                                            task_entity=task_entity,
                                            texture_set_name=texture_set_name,

--- a/server/settings/creator_plugins.py
+++ b/server/settings/creator_plugins.py
@@ -1,55 +1,55 @@
-from ayon_server.settings import BaseSettingsModel, SettingsField
+from ayonserver.settings import BaseSettingsModel, SettingsField
 
 
 class ChannelMappingItemModel(BaseSettingsModel):
-    _layout = "compact"
+    layout = "compact"
     name: str = SettingsField(title="Channel Type")
     value: str = SettingsField(title="Channel Map")
 
 
 class CreateTextureModel(BaseSettingsModel):
-    channel_mapping: list[ChannelMappingItemModel] = SettingsField(
-        default_factory=list, title="Channel Mapping")
+    channelmapping: list[ChannelMappingItemModel] = SettingsField(
+        defaultfactory=list, title="Channel Mapping")
 
 
 class CreatorsModel(BaseSettingsModel):
     CreateTextures: CreateTextureModel = SettingsField(
-        default_factory=CreateTextureModel,
+        defaultfactory=CreateTextureModel,
         title="Create Textures"
     )
 
 
-DEFAULT_CREATOR_SETTINGS = {
+DEFAULTCREATORSETTINGS = {
     "CreateTextures": {
-        "channel_mapping": [
-            {"name": "Anisotropy Angle", "value": "_Anisotropyangle"},
-            {"name": "Anisotropy Level", "value": "_Anisotropylevel"},
-            {"name": "Base Color", "value": "_BaseColor"},
-            {"name": "Metallic", "value": "_Metallic"},
-            {"name": "Roughness", "value": "_Roughness"},
-            {"name": "Normal", "value": "_Normal"},
-            {"name": "Height", "value": "_Height"},
-            {"name": "Specular Edge Color", "value": "_SpecularEdgeColor"},
-            {"name": "Opacity", "value": "_Opacity"},
-            {"name": "Displacement", "value": "_Displacement"},
-            {"name": "Glossiness", "value": "_Glossiness"},
-            {"name": "Ambient Occlusion", "value": "_AO"},
-            {"name": "Transmissive", "value": "_Transmissive"},
-            {"name": "Reflection", "value": "_Reflection"},
-            {"name": "Diffuse", "value": "_Diffuse"},
-            {"name": "Index of Refraction", "value": "_Ior"},
-            {"name": "Specular Level", "value": "_Specularlevel"},
-            {"name": "Blending Mask", "value": "_BlendingMask"},
-            {"name": "Translucency", "value": "_Translucency"},
-            {"name": "Scattering", "value": "_Scattering"},
-            {"name": "Scatter Color", "value": "_ScatterColor"},
-            {"name": "Sheen Opacity", "value": "_SheenOpacity"},
-            {"name": "Sheen Color", "value": "_SheenColor"},
-            {"name": "Coat Opacity", "value": "_CoatOpacity"},
-            {"name": "Coat Color", "value": "_CoatColor"},
-            {"name": "Coat Roughness", "value": "_CoatRoughness"},
-            {"name": "Coat Specular Level", "value": "_CoatSpecularLevel"},
-            {"name": "Coat Normal", "value": "_CoatNormal"}
+        "channelmapping": [
+            {"name": "Anisotropy Angle", "value": "Anisotropyangle"},
+            {"name": "Anisotropy Level", "value": "Anisotropylevel"},
+            {"name": "Base Color", "value": "BaseColor"},
+            {"name": "Metallic", "value": "Metallic"},
+            {"name": "Roughness", "value": "Roughness"},
+            {"name": "Normal", "value": "Normal"},
+            {"name": "Height", "value": "Height"},
+            {"name": "Specular Edge Color", "value": "SpecularEdgeColor"},
+            {"name": "Opacity", "value": "Opacity"},
+            {"name": "Displacement", "value": "Displacement"},
+            {"name": "Glossiness", "value": "Glossiness"},
+            {"name": "Ambient Occlusion", "value": "AO"},
+            {"name": "Transmissive", "value": "Transmissive"},
+            {"name": "Reflection", "value": "Reflection"},
+            {"name": "Diffuse", "value": "Diffuse"},
+            {"name": "Index of Refraction", "value": "Ior"},
+            {"name": "Specular Level", "value": "Specularlevel"},
+            {"name": "Blending Mask", "value": "BlendingMask"},
+            {"name": "Translucency", "value": "Translucency"},
+            {"name": "Scattering", "value": "Scattering"},
+            {"name": "Scatter Color", "value": "ScatterColor"},
+            {"name": "Sheen Opacity", "value": "SheenOpacity"},
+            {"name": "Sheen Color", "value": "SheenColor"},
+            {"name": "Coat Opacity", "value": "CoatOpacity"},
+            {"name": "Coat Color", "value": "CoatColor"},
+            {"name": "Coat Roughness", "value": "CoatRoughness"},
+            {"name": "Coat Specular Level", "value": "CoatSpecularLevel"},
+            {"name": "Coat Normal", "value": "CoatNormal"}
         ],
     }
 }


### PR DESCRIPTION
## Changelog Description
This PR is to add support for `$uvTileName` token in texture export regarding to the update of Substance Painter 11.0.0. 
Resolve https://github.com/ynput/ayon-substance-painter/issues/33

## Additional review information
The `$uvTileName` token is not working for the SP version elder than 11 and possibly raising exception.

## Testing notes:
1. Launch SP
2. Create texture presets with e.g. `$uvTileName_BaseColor` or like the name of the screenshot below
![image](https://github.com/user-attachments/assets/afabd79d-4ad4-4504-8c01-7363b623c2bf)
3. Publish