### PR TITLE
Do not error on opening publisher UI when no project is open

### DIFF
--- a/client/ayon_substancepainter/plugins/create/create_textures.py
+++ b/client/ayon_substancepainter/plugins/create/create_textures.py
@@ -257,6 +257,15 @@ class CreateTextures(Creator):
         ]
 
     def get_pre_create_attr_defs(self):
+
+        if not substance_painter.project.is_open():
+            return [
+                UILabelDef(
+                    "no_open_project",
+                    label="Please open a Substance Painter project first.",
+                )
+            ]
+
         # Use same attributes as for instance attributes
         attr_defs = []
         if  substance_painter.application.version_info()[0] >= 10:


### PR DESCRIPTION
## Changelog Description

Do not crash on `CreateTextures` just when opening publisher UI when no substance painter project is open yet.

## Additional review information

Fix #43

## Testing notes:

1. Open publisher UI without active substance painter project should be fine.
