### PR TITLE
implement backward compatibility for $uvTileName

### DIFF
--- a/client/ayon_substancepainter/api/lib.py
+++ b/client/ayon_substancepainter/api/lib.py
@@ -277,6 +277,7 @@ def _templates_to_regex(templates,
     }
 
     if tile_name_match:
+        # Added in Substance Painter 11.0.0
         key_matches["$uvTileName"] = tile_name_match
 
     # Turn the templates into regexes


### PR DESCRIPTION
## Changelog Description
Implement the backward compatibility for `$uvTileName` and ` set(tile.name for tile in texture_set.all_uv_tiles())`, just in case users are using the elder version of SP.

## Additional review information
Test with both SP v10 and v11

## Testing notes:
1. Launch SP
2. Create texture set
3. Publish
