### PR TITLE
Create: Use kwargs to call product name functions

### DIFF
--- a/client/ayon_substancepainter/plugins/create/create_workfile.py
+++ b/client/ayon_substancepainter/plugins/create/create_workfile.py
@@ -80,7 +80,7 @@ class CreateWorkfile(AutoCreator):
             # Update instance context if is not the same
             product_name = self.get_product_name(
                 project_name=project_name,
-                project_entity=project_entity
+                project_entity=project_entity,
                 folder_entity=folder_entity,
                 task_entity=task_entity,
                 variant=variant,

--- a/client/ayon_substancepainter/plugins/create/create_workfile.py
+++ b/client/ayon_substancepainter/plugins/create/create_workfile.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
 """Creator plugin for creating workfiles."""
-
-import ayon_api
-
 from ayon_core.pipeline import CreatedInstance, AutoCreator
 
 from ayon_substancepainter.api.pipeline import (

--- a/client/ayon_substancepainter/plugins/create/create_workfile.py
+++ b/client/ayon_substancepainter/plugins/create/create_workfile.py
@@ -47,20 +47,24 @@ class CreateWorkfile(AutoCreator):
         if current_instance is not None:
             current_folder_path = current_instance["folderPath"]
 
+        project_entity = self.create_context.get_current_project_entity()
+        folder_entity = self.create_context.get_current_folder_entity()
+        task_entity = self.create_context.get_current_task_entity()
+
+        project_name = project_entity["name"]
+        folder_path = folder_entity["path"]
+        task_name = task_entity["name"]
+        host_name = self.create_context.host_name
+
         if current_instance is None:
             self.log.info("Auto-creating workfile instance...")
-            folder_entity = ayon_api.get_folder_by_path(
-                project_name, folder_path
-            )
-            task_entity = ayon_api.get_task_by_name(
-                project_name, folder_entity["id"], task_name
-            )
             product_name = self.get_product_name(
-                project_name,
-                folder_entity,
-                task_entity,
-                variant,
-                host_name,
+                project_name=project_name,
+                project_entity=project_entity,
+                folder_entity=folder_entity,
+                task_entity=task_entity,
+                variant=variant,
+                host_name=host_name,
             )
             data = {
                 "folderPath": folder_path,
@@ -74,18 +78,13 @@ class CreateWorkfile(AutoCreator):
             or current_instance["task"] != task_name
         ):
             # Update instance context if is not the same
-            folder_entity = ayon_api.get_folder_by_path(
-                project_name, folder_path
-            )
-            task_entity = ayon_api.get_task_by_name(
-                project_name, folder_entity["id"], task_name
-            )
             product_name = self.get_product_name(
-                project_name,
-                folder_entity,
-                task_entity,
-                variant,
-                host_name,
+                project_name=project_name,
+                project_entity=project_entity
+                folder_entity=folder_entity,
+                task_entity=task_entity,
+                variant=variant,
+                host_name=host_name,
             )
             current_instance["folderPath"] = folder_path
             current_instance["task"] = task_name

--- a/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
+++ b/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
@@ -105,19 +105,19 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
         #   for now this is only done so the product name starts with
         #   'texture'
         image_product_name = get_product_name(
-            context.data["projectName"],
-            task_name,
-            task_type,
-            context.data["hostName"],
+            project_name=context.data["projectName"],
+            task_name=task_name,
+            task_type=task_type,
+            host_name=context.data["hostName"],
             product_type="texture",
             variant=instance.data["variant"] + suffix,
             project_settings=context.data["project_settings"]
         )
         image_product_group_name = get_product_name(
-            context.data["projectName"],
-            task_name,
-            task_type,
-            context.data["hostName"],
+            project_name=context.data["projectName"],
+            task_name=task_name,
+            task_type=task_type,
+            host_name=context.data["hostName"],
             product_type="texture",
             variant=instance.data["variant"],
             project_settings=context.data["project_settings"]


### PR DESCRIPTION
## Changelog Description
Use kwargs to call product name functions and use cached data to call them if possible.

## Additional review information
This is preparation for future change in `get_product_name` functionality and update of already added change in `get_product_name` method.

## Testing notes:
1. Product names are calculated correctly.
