### PR TITLE
Add callback to ensure substance is not busy while publishing

### DIFF
--- a/client/ayon_substancepainter/plugins/publish/extract_textures.py
+++ b/client/ayon_substancepainter/plugins/publish/extract_textures.py
@@ -1,3 +1,4 @@
+import substance_painter.project
 import substance_painter.export
 from ayon_core.pipeline import KnownPublishError, publish
 from ayon_substancepainter.api.lib import set_layer_stack_opacity
@@ -24,29 +25,9 @@ class ExtractTextures(publish.Extractor,
 
     def process(self, instance):
 
-        config = instance.data["exportConfig"]
-        creator_attrs = instance.data["creator_attributes"]
-        export_channel = creator_attrs.get("exportChannel", [])
-        node_ids = instance.data.get("selected_node_id", [])
-
-        with set_layer_stack_opacity(node_ids, export_channel):
-            result = substance_painter.export.export_project_textures(config)
-
-            if result.status != substance_painter.export.ExportStatus.Success:
-                raise KnownPublishError(
-                    "Failed to export texture set: {}".format(result.message)
-                )
-
-            # Log what files we generated
-            for (texture_set_name, stack_name), maps in (
-                result.textures.items()
-            ):
-                # Log our texture outputs
-                self.log.info(
-                    f"Exported stack: {texture_set_name} {stack_name}"
-                )
-                for texture_map in maps:
-                    self.log.info(f"Exported texture: {texture_map}")
+        substance_painter.project.execute_when_not_busy(
+            lambda: self._export_texture_set(instance)
+        )
 
         # We'll insert the color space data for each image instance that we
         # added into this texture set. The collector couldn't do so because
@@ -69,3 +50,35 @@ class ExtractTextures(publish.Extractor,
         # output data. Instead the separated texture instances are generated
         # from it which themselves integrate into the database.
         instance.data["integrate"] = False
+
+    def _export_texture_set(self, instance):
+        """Export the texture set for the given instance.
+
+        Args:
+            instance (pyblish.api.Instance): The instance to export.
+
+        Raises:
+            KnownPublishError: If the export fails.
+        """
+        config = instance.data["exportConfig"]
+        creator_attrs = instance.data["creator_attributes"]
+        export_channel = creator_attrs.get("exportChannel", [])
+        node_ids = instance.data.get("selected_node_id", [])
+        with set_layer_stack_opacity(node_ids, export_channel):
+            result = substance_painter.export.export_project_textures(config)
+
+            if result.status != substance_painter.export.ExportStatus.Success:
+                raise KnownPublishError(
+                    "Failed to export texture set: {}".format(result.message)
+                )
+
+            # Log what files we generated
+            for (texture_set_name, stack_name), maps in (
+                result.textures.items()
+            ):
+                # Log our texture outputs
+                self.log.info(
+                    f"Exported stack: {texture_set_name} {stack_name}"
+                )
+                for texture_map in maps:
+                    self.log.info(f"Exported texture: {texture_map}")

--- a/client/ayon_substancepainter/plugins/publish/increment_workfile.py
+++ b/client/ayon_substancepainter/plugins/publish/increment_workfile.py
@@ -6,6 +6,8 @@ from ayon_core.lib import version_up
 from ayon_core.host import IWorkfileHost
 from ayon_core.pipeline import registered_host
 
+import substance_painter.project
+
 
 class IncrementWorkfileVersion(pyblish.api.ContextPlugin):
     """Increment current workfile version."""
@@ -20,6 +22,17 @@ class IncrementWorkfileVersion(pyblish.api.ContextPlugin):
         assert all(result["success"] for result in context.data["results"]), (
             "Publishing not successful so version is not increased.")
 
+        substance_painter.project.execute_when_not_busy(
+                lambda: self._save_workfile(context)
+            )
+
+    def _save_workfile(self, context):
+        """Save the current workfile.
+
+        Args:
+            context (pyblish.api.Context): The context to use for
+            saving the workfile.
+        """
         current_filepath: str = context.data["currentFile"]
         try:
             from ayon_core.pipeline.workfile import save_next_version


### PR DESCRIPTION
## Changelog Description
This PR is to add callback in substance painter to execute exporting texture sets or saving workfile only when substance is not busy. It is to ensure the publishing progress is not overlapping with the autosaving action by Substance.
Fixes: https://github.com/ynput/ayon-substance-painter/issues/47

## Additional review information
n/a

## Testing notes:
1. Launch SP
2. Create TextureSet
3. Publish TextureSet and Workfile