### PR TITLE
Support to create reviewable for textures

### DIFF
--- a/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
+++ b/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
@@ -161,7 +161,7 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
             entity: dict = instance.data.get(
                 "taskEntity", instance.data["folderEntity"]
             )
-            fps : float = entity["attrib"]["fps"]
+            fps: float = entity["attrib"]["fps"]
             image_instance.data["fps"] = fps
             if bool(outputs[0].get("udim")):
                 udim = sorted(int(output["udim"]) for output in outputs)


### PR DESCRIPTION
## Changelog Description
This PR is to add the support to create reviewable for each texture image
Resolve https://github.com/ynput/ayon-substance-painter/issues/58


## Additional review information
n/a

## Testing notes:
1. Create Texture
2. Make sure Review toggle is on
3. Publish
4. Go to the related instance and click 
5. It should show your image as reviewables.
<img width="1844" height="882" alt="image" src="https://github.com/user-attachments/assets/926a95c7-3851-4a1c-b6ac-980730bfdd2a" />

