### PR TITLE
Introduce the maketx extractor as optional setting

### DIFF
--- a/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
+++ b/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
@@ -209,10 +209,6 @@ class CollectTextureSet(pyblish.api.InstancePlugin,
         image_instance.data["textureSetName"] = texture_set_name
         image_instance.data["textureStackName"] = stack_name
 
-        attr_values = self.get_attr_values_from_data(instance.data)
-        image_instance.data["publish_attributes"] = {
-            "ExtractMakeTX": {"active": attr_values.get("maketx", True)}
-        }
         # Store color space with the instance
         # Note: The extractor will assign it to the representation
         colorspace = outputs[0].get("colorSpace")
@@ -301,14 +297,6 @@ class CollectTextureSet(pyblish.api.InstancePlugin,
         )
         config.update(maps)
         return config
-
-    @classmethod
-    def get_attribute_defs(cls):
-        return [
-            BoolDef("maketx",
-                    label="Extract MakeTX",
-                    default=True)
-        ]
 
 
 class CollectTextureSetStagingDir(pyblish.api.InstancePlugin):

--- a/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
+++ b/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
@@ -6,6 +6,7 @@ import ayon_api
 
 import substance_painter.textureset
 from ayon_core.pipeline import tempdir
+from ayon_core.lib import BoolDef
 from ayon_substancepainter.api.lib import (
     get_parsed_export_maps,
     get_filtered_export_preset,
@@ -206,6 +207,10 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
         image_instance.data["textureSetName"] = texture_set_name
         image_instance.data["textureStackName"] = stack_name
 
+        attr_values = self.get_attr_values_from_data(instance.data)
+        image_instance.data["publish_attributes"] = {
+            "ExtractMakeTX": {"active": attr_values.get("maketx", True)}
+        }
         # Store color space with the instance
         # Note: The extractor will assign it to the representation
         colorspace = outputs[0].get("colorSpace")
@@ -294,6 +299,14 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
         )
         config.update(maps)
         return config
+
+    @classmethod
+    def get_attribute_defs(cls):
+        return [
+            BoolDef("maketx",
+                    label="Extract MakeTX",
+                    default=True)
+        ]
 
 
 class CollectTextureSetStagingDir(pyblish.api.InstancePlugin):

--- a/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
+++ b/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
@@ -6,7 +6,6 @@ import ayon_api
 
 import substance_painter.textureset
 from ayon_core.pipeline import tempdir
-from ayon_core.lib import BoolDef
 from ayon_substancepainter.api.lib import (
     get_parsed_export_maps,
     get_filtered_export_preset,

--- a/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
+++ b/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
@@ -13,9 +13,11 @@ from ayon_substancepainter.api.lib import (
     strip_template
 )
 from ayon_core.pipeline.create import get_product_name
+from ayon_core.pipeline.publish import AYONPyblishPluginMixin
 
 
-class CollectTextureSet(pyblish.api.InstancePlugin):
+class CollectTextureSet(pyblish.api.InstancePlugin,
+                        AYONPyblishPluginMixin):
     """Extract Textures using an output template config"""
     # TODO: Production-test usage of color spaces
     # TODO: Detect what source data channels end up in each file

--- a/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
+++ b/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
@@ -12,11 +12,9 @@ from ayon_substancepainter.api.lib import (
     strip_template
 )
 from ayon_core.pipeline.create import get_product_name
-from ayon_core.pipeline.publish import AYONPyblishPluginMixin
 
 
-class CollectTextureSet(pyblish.api.InstancePlugin,
-                        AYONPyblishPluginMixin):
+class CollectTextureSet(pyblish.api.InstancePlugin):
     """Extract Textures using an output template config"""
     # TODO: Production-test usage of color spaces
     # TODO: Detect what source data channels end up in each file

--- a/client/ayon_substancepainter/plugins/publish/extract_maketx.py
+++ b/client/ayon_substancepainter/plugins/publish/extract_maketx.py
@@ -119,7 +119,6 @@ class ExtractMakeTX(publish.Extractor,
 
     @classmethod
     def instance_matches_plugin_families(cls, instance: "CreatedInstance"):  # noqa: F821
-        # Show only for instances from settings based create plugins
         identifier = "io.openpype.creators.substancepainter.textureset"
         return instance.creator_identifier == identifier
 

--- a/client/ayon_substancepainter/plugins/publish/extract_maketx.py
+++ b/client/ayon_substancepainter/plugins/publish/extract_maketx.py
@@ -118,7 +118,7 @@ class ExtractMakeTX(publish.Extractor,
     order = publish.Extractor.order - 0.099
 
     @classmethod
-    def instance_matches_plugin_families(cls, instance: "CreatedInstance"):
+    def instance_matches_plugin_families(cls, instance: "CreatedInstance"):  # noqa: F821
         # Show only for instances from settings based create plugins
         identifier = "io.openpype.creators.substancepainter.textureset"
         return instance.creator_identifier == identifier

--- a/client/ayon_substancepainter/plugins/publish/extract_maketx.py
+++ b/client/ayon_substancepainter/plugins/publish/extract_maketx.py
@@ -109,8 +109,9 @@ class ExtractMakeTX(publish.Extractor,
 
     label = "Extract TX"
     hosts = ["substancepainter"]
-    families = ["image"]
+    families = ["textureSet", "image"]
     settings_category = "substancepainter"
+    optional = True
 
     # Run directly after textures export
     order = publish.Extractor.order - 0.099

--- a/client/ayon_substancepainter/plugins/publish/extract_maketx.py
+++ b/client/ayon_substancepainter/plugins/publish/extract_maketx.py
@@ -112,8 +112,16 @@ class ExtractMakeTX(publish.Extractor,
     families = ["image"]
     settings_category = "substancepainter"
 
+    # Settings
+    optional = True
     # Run directly after textures export
     order = publish.Extractor.order - 0.099
+
+    @classmethod
+    def instance_matches_plugin_families(cls, instance: "CreatedInstance"):
+        # Show only for instances from settings based create plugins
+        identifier = "io.openpype.creators.substancepainter.textureset"
+        return instance.creator_identifier == identifier
 
     def process(self, instance):
         if not self.is_active(instance.data):

--- a/client/ayon_substancepainter/plugins/publish/extract_maketx.py
+++ b/client/ayon_substancepainter/plugins/publish/extract_maketx.py
@@ -109,9 +109,8 @@ class ExtractMakeTX(publish.Extractor,
 
     label = "Extract TX"
     hosts = ["substancepainter"]
-    families = ["textureSet", "image"]
+    families = ["image"]
     settings_category = "substancepainter"
-    optional = True
 
     # Run directly after textures export
     order = publish.Extractor.order - 0.099


### PR DESCRIPTION
## Changelog Description
This PR is to introduce the maketx extractor as optional setting and make sure the extractor setting has been synchonized witht the ayon settting correctly.
Resolve: https://github.com/ynput/ayon-substance-painter/issues/19

## Additional review information
n/a

## Testing notes:
1. Create TextureSet
2. You should see the Extract tx toggle option
3. Publish successfully with/without extract tx
