### PR TITLE
Loaders: Filters by extension instead of representation name

### DIFF
--- a/client/ayon_substancepainter/plugins/load/load_mesh.py
+++ b/client/ayon_substancepainter/plugins/load/load_mesh.py
@@ -144,7 +144,8 @@ class SubstanceLoadProjectMesh(load.LoaderPlugin):
 
     product_base_types = {"*"}
     product_types = product_base_types
-    representations = {"abc", "fbx", "obj", "gltf", "usd", "usda", "usdc"}
+    representations = {"*"}
+    extensions = {"abc", "fbx", "obj", "gltf", "usd", "usda", "usdc"}
 
     label = "Load mesh"
     order = -10


### PR DESCRIPTION
## Changelog Description

Loaders: Filters by extension instead of representation name

## Additional review information

Make loaders filter by extension instead of representation name so they are less restrictive on what can be loaded.

## Testing notes:

1. Validate code changes
2. Loaders should still be able to load the right representations, etc.