### PR TITLE
Image instance: Don't use product type from texture

### DIFF
--- a/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
+++ b/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
@@ -164,7 +164,8 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
         image_instance.data["name"] = image_product_name
         image_instance.data["label"] = image_product_name
         image_instance.data["productName"] = image_product_name
-        image_instance.data["productType"] = product_type or product_base_type
+        # TODO how to get product type for image instance?
+        image_instance.data["productType"] = product_base_type
         image_instance.data["productBaseType"] = product_base_type
         image_instance.data["family"] = product_base_type
         image_instance.data["families"] = [product_base_type, "textures"]


### PR DESCRIPTION
## Changelog Description
Don't use product type from texture instance for image instance.

## Additional review information
Image instance does not have a source for custom product type thus at lease use product base type.

Issue caused with https://github.com/ynput/ayon-substance-painter/pull/67 .

## Testing notes:
1. Image products don't use product type from texture.
