### PR TITLE
Image products use product type form texture

### DIFF
--- a/client/ayon_substancepainter/plugins/create/create_textures.py
+++ b/client/ayon_substancepainter/plugins/create/create_textures.py
@@ -61,6 +61,15 @@ class CreateTextures(Creator):
                 node_number.uid() for node_number in
                 substance_painter.layerstack.get_selected_nodes(stack)]
 
+        # Define image product type
+        # NOTE: Currently use product type of texture for image. If there is
+        #   need to define different image product type in future it can be
+        #   easily added as separate setting or enum.
+        instance_data["image_product_type"] = (
+            instance_data["productType"]
+            if self.product_type_items
+            else None
+        )
         instance = self.create_instance_in_context(product_name,
                                                    instance_data)
         set_instance(
@@ -69,14 +78,26 @@ class CreateTextures(Creator):
         )
 
     def collect_instances(self):
+        # Prepare default value for image_product_type
+        # - in case there is none then use first product type item
+        #   otherwise 'image_product_type' will be None which will result in
+        #   'image' product type.
+        image_product_type = None
+        if self.product_type_items:
+            image_product_type = self.product_type_items[0].product_type
+
         for instance in get_instances():
             product_base_type = instance.get("productBaseType")
             if not product_base_type:
                 product_base_type = instance.get("productType")
+
             if (
                 instance.get("creator_identifier") == self.identifier
                 or product_base_type == self.product_base_type
             ):
+                # Fill image_product_type for instances created before this
+                #   was added if not already set
+                instance.setdefault("image_product_type", image_product_type)
                 self.create_instance_in_context_from_existing(instance)
 
     def update_instances(self, update_list):

--- a/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
+++ b/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
@@ -110,10 +110,7 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
         map_identifier = strip_template(template)
         suffix += f".{map_identifier}"
 
-        # Keep product type from instance if was customized
-        product_type = instance.data["productType"]
-        if product_type == instance.data["productBaseType"]:
-            product_type = None
+        product_type = instance.data["image_product_type"]
 
         # TODO: The product type actually isn't 'texture' currently but
         #   for now this is only done so the product name starts with


### PR DESCRIPTION
## Changelog Description
Set 'image_product_type' on texture instance with product type from texture.

## Additional review information
This probably not correct fix but it fixes very specific issue. Image instance should inherit product type in case it was customized on texture and use `image` in case it was not customized. Previous logic did work except one case: custom product type set to `texture`. With current changes the image product type is set on the instance explicitly, if product type item was used then the product type is filled otherwise `None` is used. Existing instances will use first product type item or `None` on collection.

This does solve the current issue, by fixing the one missed use-case, but we should discuss better solution for image product type definition (probably in different PR).

## Testing notes:
1. If custom product type items are defined for texture product instance, the product type is also used for image instance.
2. If custom product type items are not defined then image instance will have `image` product type.
