### PR TITLE
Image products use the product type

### DIFF
--- a/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
+++ b/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
@@ -162,7 +162,7 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
         image_instance.data["label"] = image_product_name
         image_instance.data["productName"] = image_product_name
         # TODO how to get product type for image instance?
-        image_instance.data["productType"] = product_base_type
+        image_instance.data["productType"] = product_type
         image_instance.data["productBaseType"] = product_base_type
         image_instance.data["family"] = product_base_type
         image_instance.data["families"] = [product_base_type, "textures"]


### PR DESCRIPTION
## Changelog Description
Set product type to product type which is defined on texture instance.

## Testing notes:
1. Define custom product types for texture create plugin.
2. Create the custom product type and publish the texture instance.
3. Integrated image instances should have product type from the texture instance .
