### PR TITLE
Make sure product type is set on image instance

### DIFF
--- a/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
+++ b/client/ayon_substancepainter/plugins/publish/collect_textureset_images.py
@@ -162,7 +162,7 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
         image_instance.data["label"] = image_product_name
         image_instance.data["productName"] = image_product_name
         # TODO how to get product type for image instance?
-        image_instance.data["productType"] = product_type
+        image_instance.data["productType"] = product_type or product_base_type
         image_instance.data["productBaseType"] = product_base_type
         image_instance.data["family"] = product_base_type
         image_instance.data["families"] = [product_base_type, "textures"]


### PR DESCRIPTION
## Changelog Description
Image instance does have product type available on instance data.

## Additional review information
Without having product type items the product type is `None` which should be filled with product base type for publishing purposes.

## Testing notes:
1. Remove product type items from texture create plugin (in settings).
2. Create textureset.
3. Publish.
4. Published instance should be able to use `{product[type]}` in publish template.